### PR TITLE
Fix a typo in package.json to map the type definition file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Brazilian personal documents validation - cpf, cnpj, titulo, pis/pasep, cnh, renavam, processos judiciais, protocolo federal, código de rastreamento dos correios",
   "version": "1.4.4",
   "main": "dist/index.js",
-  "types": "./dist/types.d.ts",
+  "types": "./dist/index.d.ts",
   "author": "Cláudio Medeiros <klawdyo@gmail.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Hi @klawdyo,

First of all thanks for this wonderful package. And I'm opening a small pull request just to fix a typo in `package.json` file to map the `types` entry to the file `index.d.ts`.